### PR TITLE
Adjust torrents volume mount to allow hardinking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - TZ=Europe/Stockholm
     volumes:
       - "~/config/transmission:/config"
-      - "~/data/downloads/torrents:/downloads"
+      - "~/data/downloads/torrents:/data/downloads/torrents"
     ports:
       - 9091:9091
       - 51413:51413


### PR DESCRIPTION
The current method of how you mounted the downloads ` ~/data/downloads/torrents:/downloads` means that when an *arr picks up a download it will have to copy the data, leaving a copy in the DL folder until seeding goals are met. This means double space use and excessive disk IO. This is because its a move across file systems  from `/downloads` to `/data`.

Instead by mounting as  `~/data/downloads/torrents:/data/downloads/torrents` then *arr apps and transmission are referencing the same volume and the files are hardlinked into the media library, in an instant operation (instead of copy) and using only 1 x the space.